### PR TITLE
Added Retired Key History Support to PIV.tokend

### DIFF
--- a/Tokend-40596/PIV/PIVDefines.h
+++ b/Tokend-40596/PIV/PIVDefines.h
@@ -134,6 +134,68 @@
 //	X.509 Certificate for Card Authentication 2.16.840.1.101.3.7.2.5.0 '5FC101' O
 #define PIV_OBJECT_ID_X509_CERTIFICATE_CARD_AUTHENTICATION	0x5F, 0xC1, 0x01
 
+//	NIST SP800-73-3 optional 20 retired key certificate objects
+
+//	X.509 Certificate for Key Management History 1 - 2.16.840.1.101.3.7.2.16.1 '5FC10D' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H1	0x5F, 0xC1, 0x0D
+
+//	X.509 Certificate for Key Management History 2 - 2.16.840.1.101.3.7.2.16.2 '5FC10E' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H2	0x5F, 0xC1, 0x0E
+
+//	X.509 Certificate for Key Management History 3 - 2.16.840.1.101.3.7.2.16.3 '5FC10F' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H3	0x5F, 0xC1, 0x0F
+
+//	X.509 Certificate for Key Management History 4 - 2.16.840.1.101.3.7.2.16.4 '5FC110' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H4	0x5F, 0xC1, 0x10
+
+//	X.509 Certificate for Key Management History 5 - 2.16.840.1.101.3.7.2.16.5 '5FC111' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H5	0x5F, 0xC1, 0x11
+
+//	X.509 Certificate for Key Management History 6 - 2.16.840.1.101.3.7.2.16.6 '5FC112' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H6	0x5F, 0xC1, 0x12
+
+//	X.509 Certificate for Key Management History 7 - 2.16.840.1.101.3.7.2.16.7 '5FC113' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H7	0x5F, 0xC1, 0x13
+
+//	X.509 Certificate for Key Management History 8 - 2.16.840.1.101.3.7.2.16.8 '5FC114' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H8	0x5F, 0xC1, 0x14
+
+//	X.509 Certificate for Key Management History 9 - 2.16.840.1.101.3.7.2.16.9 '5FC115' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H9	0x5F, 0xC1, 0x15
+
+//	X.509 Certificate for Key Management History 10 - 2.16.840.1.101.3.7.2.16.10 '5FC116' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H10	0x5F, 0xC1, 0x16
+
+//	X.509 Certificate for Key Management History 11 - 2.16.840.1.101.3.7.2.16.11 '5FC117' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H11	0x5F, 0xC1, 0x17
+
+//	X.509 Certificate for Key Management History 12 - 2.16.840.1.101.3.7.2.16.12 '5FC118' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H12	0x5F, 0xC1, 0x18
+
+//	X.509 Certificate for Key Management History 13 - 2.16.840.1.101.3.7.2.16.13 '5FC119' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H13	0x5F, 0xC1, 0x19
+
+//	X.509 Certificate for Key Management History 14 - 2.16.840.1.101.3.7.2.16.14 '5FC11A' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H14	0x5F, 0xC1, 0x1A
+
+//	X.509 Certificate for Key Management History 15 - 2.16.840.1.101.3.7.2.16.15 '5FC11B' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H15	0x5F, 0xC1, 0x1B
+
+//	X.509 Certificate for Key Management History 16 - 2.16.840.1.101.3.7.2.16.16 '5FC11C' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H16	0x5F, 0xC1, 0x1C
+
+//	X.509 Certificate for Key Management History 17 - 2.16.840.1.101.3.7.2.16.17 '5FC11D' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H17	0x5F, 0xC1, 0x1D
+
+//	X.509 Certificate for Key Management History 18 - 2.16.840.1.101.3.7.2.16.18 '5FC11E' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H18	0x5F, 0xC1, 0x1E
+
+//	X.509 Certificate for Key Management History 19 - 2.16.840.1.101.3.7.2.16.19 '5FC11F' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H19	0x5F, 0xC1, 0x1F
+
+//	X.509 Certificate for Key Management History 20 - 2.16.840.1.101.3.7.2.16.20 '5FC120' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H20	0x5F, 0xC1, 0x20
+
 // ----------------------------------------------------------------------------
 /*
 	Verify APDU	[NISTIR6887 5.1.2.4]
@@ -328,6 +390,68 @@ Status Tuples (STs) 0xFC Fixed 0
 #define PIV_KEYREF_PIV_DIGITAL_SIGNATURE   0x9C
 #define PIV_KEYREF_PIV_KEY_MANAGEMENT      0x9D
 #define PIV_KEYREF_PIV_CARD_AUTHENTICATION 0x9E
+
+//	NIST SP800-73-3 - 5 retired key references
+
+//	KM History key 1 - 2.16.840.1.101.3.7.2.9999.101
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H1   0x82
+
+//	KM History key 2 - 2.16.840.1.101.3.7.2.9999.102
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H2   0x83
+
+//	KM History key 3 - 2.16.840.1.101.3.7.2.9999.103
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H3   0x84
+
+//	KM History key 4 - 2.16.840.1.101.3.7.2.9999.104
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H4   0x85
+
+//	KM History key 5 - 2.16.840.1.101.3.7.2.9999.105
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H5   0x86
+
+//	KM History key 6 - 2.16.840.1.101.3.7.2.9999.106
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H6   0x87
+
+//	KM History key 7 - 2.16.840.1.101.3.7.2.9999.107
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H7   0x88
+
+//	KM History key 8 - 2.16.840.1.101.3.7.2.9999.108
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H8   0x89
+
+//	KM History key 9 - 2.16.840.1.101.3.7.2.9999.109
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H9   0x8A
+
+//	KM History key 10 - 2.16.840.1.101.3.7.2.9999.110
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H10   0x8B
+
+//	KM History key 11 - 2.16.840.1.101.3.7.2.9999.111
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H11   0x8C
+
+//	KM History key 12 - 2.16.840.1.101.3.7.2.9999.112
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H12   0x8D
+
+//	KM History key 13 - 2.16.840.1.101.3.7.2.9999.113
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H13   0x8E
+
+//	KM History key 14 - 2.16.840.1.101.3.7.2.9999.114
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H14   0x8F
+
+//	KM History key 15 - 2.16.840.1.101.3.7.2.9999.115
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H15   0x90
+
+//	KM History key 16 - 2.16.840.1.101.3.7.2.9999.116
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H16   0x91
+
+//	KM History key 17 - 2.16.840.1.101.3.7.2.9999.117
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H17   0x92
+
+//	KM History key 18 - 2.16.840.1.101.3.7.2.9999.118
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H18   0x93
+
+//	KM History key 19 - 2.16.840.1.101.3.7.2.9999.119
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H19   0x94
+
+//	KM History key 20 - 2.16.840.1.101.3.7.2.9999.120
+#define PIV_KEYREF_PIV_KEY_MANAGEMENT_H20   0x95
 
 /*
 	Algorithm Identifiers:

--- a/Tokend-40596/PIV/PIVToken.cpp
+++ b/Tokend-40596/PIV/PIVToken.cpp
@@ -107,7 +107,27 @@ static const unsigned char oidX509CertificatePIVAuthentication[] = { PIV_OBJECT_
 static const unsigned char oidX509CertificateDigitalSignature[] = { PIV_OBJECT_ID_X509_CERTIFICATE_DIGITAL_SIGNATURE };
 static const unsigned char oidX509CertificateKeyManagement[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT };
 static const unsigned char oidX509CertificateCardAuthentication[] = { PIV_OBJECT_ID_X509_CERTIFICATE_CARD_AUTHENTICATION };
-
+//	NIST SP800-73-3 20 optional retired key certificates
+static const unsigned char oidX509CertificateKeyManagementHistory1[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H1 };
+static const unsigned char oidX509CertificateKeyManagementHistory2[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H2 };
+static const unsigned char oidX509CertificateKeyManagementHistory3[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H3 };
+static const unsigned char oidX509CertificateKeyManagementHistory4[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H4 };
+static const unsigned char oidX509CertificateKeyManagementHistory5[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H5 };
+static const unsigned char oidX509CertificateKeyManagementHistory6[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H6 };
+static const unsigned char oidX509CertificateKeyManagementHistory7[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H7 };
+static const unsigned char oidX509CertificateKeyManagementHistory8[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H8 };
+static const unsigned char oidX509CertificateKeyManagementHistory9[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H9 };
+static const unsigned char oidX509CertificateKeyManagementHistory10[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H10 };
+static const unsigned char oidX509CertificateKeyManagementHistory11[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H11 };
+static const unsigned char oidX509CertificateKeyManagementHistory12[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H12 };
+static const unsigned char oidX509CertificateKeyManagementHistory13[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H13 };
+static const unsigned char oidX509CertificateKeyManagementHistory14[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H14 };
+static const unsigned char oidX509CertificateKeyManagementHistory15[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H15 };
+static const unsigned char oidX509CertificateKeyManagementHistory16[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H16 };
+static const unsigned char oidX509CertificateKeyManagementHistory17[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H17 };
+static const unsigned char oidX509CertificateKeyManagementHistory18[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H18 };
+static const unsigned char oidX509CertificateKeyManagementHistory19[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H19 };
+static const unsigned char oidX509CertificateKeyManagementHistory20[] = { PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H20 };
 
 #pragma mark ---------- NO/MINOR MODIFICATION NEEDED ----------
 
@@ -392,7 +412,28 @@ void PIVToken::populate()
 		oidX509CertificatePIVAuthentication,	// 0x9A
 		oidX509CertificateDigitalSignature,		// 0x9C
 		oidX509CertificateKeyManagement,		// 0x9D
-		oidX509CertificateCardAuthentication	// 0x9E
+		oidX509CertificateCardAuthentication,	// 0x9E
+		// NIST SP800-73-3 - 20 optional retired key certificates
+		oidX509CertificateKeyManagementHistory1,	// 0x82
+		oidX509CertificateKeyManagementHistory2,	// 0x83
+		oidX509CertificateKeyManagementHistory3,	// 0x84
+		oidX509CertificateKeyManagementHistory4,	// 0x85
+		oidX509CertificateKeyManagementHistory5,	// 0x86		
+		oidX509CertificateKeyManagementHistory6,	// 0x87
+		oidX509CertificateKeyManagementHistory7,	// 0x88
+		oidX509CertificateKeyManagementHistory8,	// 0x89
+		oidX509CertificateKeyManagementHistory9,	// 0x8A
+		oidX509CertificateKeyManagementHistory10,	// 0x8B
+		oidX509CertificateKeyManagementHistory11,	// 0x8C	
+		oidX509CertificateKeyManagementHistory12,	// 0x8D	
+		oidX509CertificateKeyManagementHistory13,	// 0x8E	
+		oidX509CertificateKeyManagementHistory14,	// 0x8F	
+		oidX509CertificateKeyManagementHistory15,	// 0x90	
+		oidX509CertificateKeyManagementHistory16,	// 0x91	
+		oidX509CertificateKeyManagementHistory17,	// 0x92	
+		oidX509CertificateKeyManagementHistory18,	// 0x93	
+		oidX509CertificateKeyManagementHistory19,	// 0x94	
+		oidX509CertificateKeyManagementHistory20	// 0x95			
 	};
 
 	const char *certNames[] = 
@@ -400,7 +441,29 @@ void PIVToken::populate()
 		"PIV Authentication Certificate",
 		"Digital Signature Certificate",
 		"Key Management Certificate",
-		"Card Authentication Certificate"
+		"Card Authentication Certificate",
+		// NIST SP800-73-3 - 20 optional retired certificate names	
+		"Key Management History 1 Certificate",
+		"Key Management History 2 Certificate",
+		"Key Management History 3 Certificate",
+		"Key Management History 4 Certificate",
+		"Key Management History 5 Certificate",
+		"Key Management History 6 Certificate",
+		"Key Management History 7 Certificate",
+		"Key Management History 8 Certificate",
+		"Key Management History 9 Certificate",
+		"Key Management History 10 Certificate",
+		"Key Management History 11 Certificate",
+		"Key Management History 12 Certificate",
+		"Key Management History 13 Certificate",
+		"Key Management History 14 Certificate",
+		"Key Management History 15 Certificate",
+		"Key Management History 16 Certificate",
+		"Key Management History 17 Certificate",
+		"Key Management History 18 Certificate",
+		"Key Management History 19 Certificate",
+		"Key Management History 20 Certificate"
+		// ======================= key history support ================================		
 	};
 
 	const char *keyNames[] = 
@@ -408,7 +471,29 @@ void PIVToken::populate()
 		"PIV Authentication Private Key",	// Keyref 9A
 		"Digital Signature Private Key",	// Keyref 9C
 		"Key Management Private Key",		// Keyref 9D
-		"Card Authentication Private Key"	// Keyref 9E
+		"Card Authentication Private Key",	// Keyref 9E
+		// NIST SP800-73-3 - 20 optional retired key names
+		"Key Management History 1 Private Key",	// Keyref 82
+		"Key Management History 2 Private Key",	// Keyref 83
+		"Key Management History 3 Private Key",	// Keyref 84
+		"Key Management History 4 Private Key",	// Keyref 85
+		"Key Management History 5 Private Key",	// Keyref 86
+		"Key Management History 6 Private Key",	// Keyref 87
+		"Key Management History 7 Private Key",	// Keyref 88
+		"Key Management History 8 Private Key",	// Keyref 89
+		"Key Management History 9 Private Key",	// Keyref 8A
+		"Key Management History 10 Private Key",	// Keyref 8B
+		"Key Management History 11 Private Key",	// Keyref 8C
+		"Key Management History 12 Private Key",	// Keyref 8D
+		"Key Management History 13 Private Key",	// Keyref 8E
+		"Key Management History 14 Private Key",	// Keyref 8F
+		"Key Management History 15 Private Key",	// Keyref 90
+		"Key Management History 16 Private Key",	// Keyref 91
+		"Key Management History 17 Private Key",	// Keyref 92
+		"Key Management History 18 Private Key",	// Keyref 93
+		"Key Management History 19 Private Key",	// Keyref 94
+		"Key Management History 20 Private Key"	// Keyref 95
+		// ======================= key history support ================================
 	};
 
 	const unsigned char keyRefs[] =
@@ -416,7 +501,29 @@ void PIVToken::populate()
 		PIV_KEYREF_PIV_AUTHENTICATION,
 		PIV_KEYREF_PIV_DIGITAL_SIGNATURE,
 		PIV_KEYREF_PIV_KEY_MANAGEMENT,
-		PIV_KEYREF_PIV_CARD_AUTHENTICATION
+		PIV_KEYREF_PIV_CARD_AUTHENTICATION,
+		// NIST SP800-73-3 - 20 optional retired key references
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H1,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H2,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H3,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H4,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H5,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H6,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H7,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H8,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H9,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H10,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H11,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H12,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H13,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H14,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H15,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H16,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H17,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H18,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H19,
+		PIV_KEYREF_PIV_KEY_MANAGEMENT_H20
+		// ======================= key history support ================================
 	};
 
 	for (unsigned int ix=0;ix<sizeof(certids)/sizeof(certids[0]);++ix)

--- a/Tokend-40596/PIV/PIVToken.h
+++ b/Tokend-40596/PIV/PIVToken.h
@@ -116,6 +116,67 @@
 //	X.509 Certificate for Card Authentication 2.16.840.1.101.3.7.2.5.0	0x5FC101	O
 #define PIV_OBJECT_ID_X509_CERTIFICATE_CARD_AUTHENTICATION	0x5F, 0xC1, 0x01
 
+// NIST SP800-73-3 - 20 optional retired key certificates
+
+//	X.509 Certificate for Key Management History 1 - 2.16.840.1.101.3.7.2.16.1 '5FC10D' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H1	0x5F, 0xC1, 0x0D
+
+//	X.509 Certificate for Key Management History 2 - 2.16.840.1.101.3.7.2.16.2 '5FC10E' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H2	0x5F, 0xC1, 0x0E
+
+//	X.509 Certificate for Key Management History 3 - 2.16.840.1.101.3.7.2.16.3 '5FC10F' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H3	0x5F, 0xC1, 0x0F
+
+//	X.509 Certificate for Key Management History 4 - 2.16.840.1.101.3.7.2.16.4 '5FC110' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H4	0x5F, 0xC1, 0x10
+
+//	X.509 Certificate for Key Management History 5 - 2.16.840.1.101.3.7.2.16.5 '5FC111' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H5	0x5F, 0xC1, 0x11
+
+//	X.509 Certificate for Key Management History 6 - 2.16.840.1.101.3.7.2.16.6 '5FC112' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H6	0x5F, 0xC1, 0x12
+
+//	X.509 Certificate for Key Management History 7 - 2.16.840.1.101.3.7.2.16.7 '5FC113' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H7	0x5F, 0xC1, 0x13
+
+//	X.509 Certificate for Key Management History 8 - 2.16.840.1.101.3.7.2.16.8 '5FC114' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H8	0x5F, 0xC1, 0x14
+
+//	X.509 Certificate for Key Management History 9 - 2.16.840.1.101.3.7.2.16.9 '5FC115' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H9	0x5F, 0xC1, 0x15
+
+//	X.509 Certificate for Key Management History 10 - 2.16.840.1.101.3.7.2.16.10 '5FC116' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H10	0x5F, 0xC1, 0x16
+
+//	X.509 Certificate for Key Management History 11 - 2.16.840.1.101.3.7.2.16.11 '5FC117' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H11	0x5F, 0xC1, 0x17
+
+//	X.509 Certificate for Key Management History 12 - 2.16.840.1.101.3.7.2.16.12 '5FC118' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H12	0x5F, 0xC1, 0x18
+
+//	X.509 Certificate for Key Management History 13 - 2.16.840.1.101.3.7.2.16.13 '5FC119' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H13	0x5F, 0xC1, 0x19
+
+//	X.509 Certificate for Key Management History 14 - 2.16.840.1.101.3.7.2.16.14 '5FC11A' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H14	0x5F, 0xC1, 0x1A
+
+//	X.509 Certificate for Key Management History 15 - 2.16.840.1.101.3.7.2.16.15 '5FC11B' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H15	0x5F, 0xC1, 0x1B
+
+//	X.509 Certificate for Key Management History 16 - 2.16.840.1.101.3.7.2.16.16 '5FC11C' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H16	0x5F, 0xC1, 0x1C
+
+//	X.509 Certificate for Key Management History 17 - 2.16.840.1.101.3.7.2.16.17 '5FC11D' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H17	0x5F, 0xC1, 0x1D
+
+//	X.509 Certificate for Key Management History 18 - 2.16.840.1.101.3.7.2.16.18 '5FC11E' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H18	0x5F, 0xC1, 0x1E
+
+//	X.509 Certificate for Key Management History 19 - 2.16.840.1.101.3.7.2.16.19 '5FC11F' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H19	0x5F, 0xC1, 0x1F
+
+//	X.509 Certificate for Key Management History 20 - 2.16.840.1.101.3.7.2.16.20 '5FC120' O
+#define  PIV_OBJECT_ID_X509_CERTIFICATE_KEY_MANAGEMENT_H20	0x5F, 0xC1, 0x20
 
 class PIVSchema;
 class PIVCCC;


### PR DESCRIPTION
By submitting a request, you represent that you have the right to license
your contribution to the community, and agree that your contributions are
licensed under the [GNU Lesser General Public License Version
2.1](SmartcardCCID/COPYING) (for just the SmartCardCCID subproject of the
Smart Card Services project) or the [Apple Public Source License Version
2.0](SmartCardServices/APPLE_LICENSE) (for the remainder of the Smart Card
Services project).

For existing files modified by your request, you represent that you have
retained any existing copyright notices and licensing terms. For each new
file in your request, you represent that you have added to the file a
copyright notice (including the year and the copyright owner's name) and the
Smart Card Services' licensing terms.

Before submitting the request, please make sure that your request follows
the [Smart Card Services' guidelines for contributing code](Dev_Guide).

Added functionality for NIST SP800-73-3 specified 20 optional retired key certificates